### PR TITLE
test: we're just testing

### DIFF
--- a/.github/workflows/check_pr_titles.yaml
+++ b/.github/workflows/check_pr_titles.yaml
@@ -57,9 +57,11 @@ jobs:
           # build command so build lines don't pollute `output` below
           lake build check_title_labels
 
+          set +e
           # Capture output and exit code
           output=$(lake exe check_title_labels --labels "$label_names" "$TITLE" 2>&1)
           exit_code=$?
+          set -e
 
           if [ $exit_code -eq 0 ]; then
             echo "Check passed"

--- a/.github/workflows/check_pr_titles.yaml
+++ b/.github/workflows/check_pr_titles.yaml
@@ -22,6 +22,7 @@ jobs:
           echo "Action: ${{ github.event.action }}"
           echo "Changes: ${{ toJson(github.event.changes) }}"
           echo "Has title change: ${{ github.event.changes.title != null }}"
+          echo "pull_request object: ${{ toJson(github.event.pull_request) }}"
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/.github/workflows/check_pr_titles.yaml
+++ b/.github/workflows/check_pr_titles.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Add comment to fix PR title
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        if: failure() && steps.pr-title-check.outcome == 'failure'
+        if: failure() && steps.pr-title-check.outputs.errors
         with:
           header: 'PR Title Check'
           message: |

--- a/.github/workflows/check_pr_titles.yaml
+++ b/.github/workflows/check_pr_titles.yaml
@@ -19,10 +19,12 @@ jobs:
     steps:
       - name: Debug event data
         run: |
-          echo "Action: ${{ github.event.action }}"
-          echo "Changes: ${{ toJson(github.event.changes) }}"
-          echo "Has title change: ${{ github.event.changes.title != null }}"
-          echo "pull_request object: ${{ toJson(github.event.pull_request) }}"
+          # do nothing
+        env:
+          action: ${{ github.event.action }}
+          Changes: ${{ toJson(github.event.changes) }}
+          has_title_change: ${{ github.event.changes.title != null }}
+          pull_request: ${{ toJson(github.event.pull_request) }}
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -36,7 +38,7 @@ jobs:
 
       - name: check the PR title format
         id: pr-title-check
-        if: github.event.pull_request.draft == false && github.event.pull_request.base == 'master'
+        if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'master'
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |

--- a/.github/workflows/check_pr_titles.yaml
+++ b/.github/workflows/check_pr_titles.yaml
@@ -69,7 +69,7 @@ jobs:
               echo "errors<<EOF"
               echo "$output"
               echo "EOF"
-            } tee -a "$GITHUB_OUTPUT"
+            } | tee -a "$GITHUB_OUTPUT"
             exit "$exit_code"
           fi
 

--- a/.github/workflows/check_pr_titles.yaml
+++ b/.github/workflows/check_pr_titles.yaml
@@ -57,11 +57,9 @@ jobs:
           # build command so build lines don't pollute `output` below
           lake build check_title_labels
 
-          # Capture output and exit code (disable -e temporarily)
-          set +e
+          # Capture output and exit code
           output=$(lake exe check_title_labels --labels "$label_names" "$TITLE" 2>&1)
           exit_code=$?
-          set -e
 
           if [ $exit_code -eq 0 ]; then
             echo "Check passed"
@@ -71,13 +69,13 @@ jobs:
               echo "errors<<EOF"
               echo "$output"
               echo "EOF"
-            } >> "$GITHUB_OUTPUT"
+            } tee -a "$GITHUB_OUTPUT"
             exit "$exit_code"
           fi
 
       - name: Add comment to fix PR title
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        if: ${{ steps.pr-title-check.outputs.success == 'false'}}
+        if: ${{ failure() && steps.pr-title-check.outputs.success == 'false'}}
         with:
           header: 'PR Title Check'
           message: |

--- a/.github/workflows/check_pr_titles.yaml
+++ b/.github/workflows/check_pr_titles.yaml
@@ -14,9 +14,14 @@ permissions:
 
 jobs:
   check_title:
-    if: github.repository == 'leanprover-community/mathlib4' && (github.event.action == 'opened' || github.event.changes.title.from)
+    if: github.repository == 'bryangingechen/mathlib4' && (github.event.action == 'opened' || (github.event.action == 'edited' && github.event.changes.title))
     runs-on: ubuntu-latest
     steps:
+      - name: Debug event data
+        run: |
+          echo "Action: ${{ github.event.action }}"
+          echo "Changes: ${{ toJson(github.event.changes) }}"
+          echo "Has title change: ${{ github.event.changes.title != null }}"
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -36,6 +41,13 @@ jobs:
         run: |
           set -eo pipefail
           echo "$TITLE"
+
+          # Skip check if title starts with "[Merged by Bors] - "
+          if [[ "$TITLE" == "[Merged by Bors] - "* ]]; then
+            echo "Skipping check for Bors-merged PR"
+            exit 0
+          fi
+
           label_names=$(echo "${{ toJson(github.event.pull_request.labels) }}" | jq -r '.[].name')
           echo "$label_names"
 

--- a/.github/workflows/check_pr_titles.yaml
+++ b/.github/workflows/check_pr_titles.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   check_title:
-    if: github.repository == 'bryangingechen/mathlib4' && (github.event.action == 'opened' || (github.event.action == 'edited' && github.event.changes.title))
+    if: github.repository == 'leanprover-community/mathlib4' && (github.event.action == 'opened' || (github.event.action == 'edited' && github.event.changes.title))
     runs-on: ubuntu-latest
     steps:
       - name: Debug event data

--- a/.github/workflows/check_pr_titles.yaml
+++ b/.github/workflows/check_pr_titles.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Add comment to fix PR title
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        if: ${{ failure() && steps.pr-title-check.outputs.success == 'false'}}
+        if: failure() && steps.pr-title-check.outcome == 'failure'
         with:
           header: 'PR Title Check'
           message: |
@@ -124,7 +124,7 @@ jobs:
             </details>
 
       - name: Add comment that PR title is fixed
-        if: ${{ steps.pr-title-check.outputs.success == 'true'}}
+        if: steps.pr-title-check.outcome == 'success'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: 'PR Title Check'

--- a/.github/workflows/check_pr_titles.yaml
+++ b/.github/workflows/check_pr_titles.yaml
@@ -42,7 +42,7 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          set -eo pipefail
+          set -o pipefail
           echo "$TITLE"
 
           # Skip check if title starts with "[Merged by Bors] - "
@@ -57,12 +57,16 @@ jobs:
           # build command so build lines don't pollute `output` below
           lake build check_title_labels
 
-          # Capture output and exit code
-          if output=$(lake exe check_title_labels --labels "$label_names" "$TITLE" 2>&1); then
+          # Capture output and exit code (disable -e temporarily)
+          set +e
+          output=$(lake exe check_title_labels --labels "$label_names" "$TITLE" 2>&1)
+          exit_code=$?
+          set -e
+
+          if [ $exit_code -eq 0 ]; then
             echo "Check passed"
           else
-            exit_code="$?"
-            # Escape and set the output for use in subsequent steps
+            # Set the output for use in subsequent steps
             {
               echo "errors<<EOF"
               echo "$output"

--- a/.github/workflows/check_pr_titles.yaml
+++ b/.github/workflows/check_pr_titles.yaml
@@ -82,8 +82,7 @@ jobs:
           header: 'PR Title Check'
           message: |
             ### 🚨 PR Title Needs Formatting
-            Please update the title to match our
-            [commit style conventions](https://leanprover-community.github.io/contribute/commit.html).
+            Please update the title to match our [commit style conventions](https://leanprover-community.github.io/contribute/commit.html).
 
             Errors from script:
             ```
@@ -134,6 +133,5 @@ jobs:
           only_update: true
           message: |
             ### ✅ PR Title Formatted Correctly
-            The title of this PR has been updated to match our
-            [commit style conventions](https://leanprover-community.github.io/contribute/commit.html).
+            The title of this PR has been updated to match our [commit style conventions](https://leanprover-community.github.io/contribute/commit.html).
             Thank you!

--- a/.github/workflows/check_pr_titles.yaml
+++ b/.github/workflows/check_pr_titles.yaml
@@ -14,17 +14,9 @@ permissions:
 
 jobs:
   check_title:
-    if: github.repository == 'bryangingechen/mathlib4' && (github.event.action == 'opened' || (github.event.action == 'edited' && github.event.changes.title))
+    if: github.repository == 'leanprover-community/mathlib4' && (github.event.action == 'opened' || (github.event.action == 'edited' && github.event.changes.title))
     runs-on: ubuntu-latest
     steps:
-      - name: Debug event data
-        run: |
-          # do nothing
-        env:
-          action: ${{ github.event.action }}
-          Changes: ${{ toJson(github.event.changes) }}
-          has_title_change: ${{ github.event.changes.title != null }}
-          pull_request: ${{ toJson(github.event.pull_request) }}
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
balha

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
